### PR TITLE
Linux support for running locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ try { // Dynamic import, set to null on failure
   hideConsole = null;
 }
 
-const startupLink = join(`file://${__dirname}`, './html/startup.html');
+const startupLink = join('file:', __dirname, './html/startup.html');
 const startupHTML = fs.readFileSync(join(__dirname, './html/startup.html'), 'utf8');
 
 /**

--- a/index.js
+++ b/index.js
@@ -11,7 +11,12 @@ import * as pBrowsers from '@puppeteer/browsers';
 import * as cliProgress from 'cli-progress';
 import fs from 'fs-extra';
 import { join } from 'node:path';
-import { hideConsole } from 'node-hide-console-window';
+
+try { // Dynamic import, set to null on failure
+  var hideConsole = (await import('node-hide-console-window')).hideConsole;
+} catch (es) {
+  hideConsole = null;
+}
 
 const startupLink = join(__dirname, './html/startup.html');
 const startupHTML = fs.readFileSync(join(__dirname, './html/startup.html'), 'utf8');
@@ -115,7 +120,11 @@ async function init() {
   // Init database
   await db.init();
   const { page, browser } = await setupBrowser();
-  hideConsole();
+  
+  if (hideConsole) { // Check import was success
+    hideConsole();
+  }
+  
   // Setup user logging
   initUtils(page);
   // Wait for path decision

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ try { // Dynamic import, set to null on failure
   hideConsole = null;
 }
 
-const startupLink = join('file://', __dirname, './html/startup.html');
+const startupLink = join(`file://${__dirname}`, './html/startup.html');
 const startupHTML = fs.readFileSync(join(__dirname, './html/startup.html'), 'utf8');
 
 /**

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ try { // Dynamic import, set to null on failure
   hideConsole = null;
 }
 
-const startupLink = join(__dirname, './html/startup.html');
+const startupLink = join('file://', __dirname, './html/startup.html');
 const startupHTML = fs.readFileSync(join(__dirname, './html/startup.html'), 'utf8');
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cli-progress": "^3.12.0",
         "fs-extra": "^11.1.1",
         "got": "^13.0.0",
-        "node-hide-console-window": "^2.1.1",
+        "node-hide-console-window": "*",
         "puppeteer-core": "^20.4.0",
         "sqlite": "^4.2.1",
         "sqlite3": "^5.1.6"
@@ -26,6 +26,9 @@
       "devDependencies": {
         "caxa": "^3.0.1",
         "eslint": "^8.41.0"
+      },
+      "optionalDependencies": {
+        "node-hide-console-window": "^2.1.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2836,6 +2839,7 @@
       "resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.1.1.tgz",
       "integrity": "sha512-6knDFNCPJhgbXF10xJWVJb4COe6pvr4pI6wX4B3g9owErZD7oltrqiZS6wtoAH81dZUZFe6ys+kZDpcsH9nfqw==",
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "win32"
       ]
@@ -6145,7 +6149,8 @@
     "node-hide-console-window": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.1.1.tgz",
-      "integrity": "sha512-6knDFNCPJhgbXF10xJWVJb4COe6pvr4pI6wX4B3g9owErZD7oltrqiZS6wtoAH81dZUZFe6ys+kZDpcsH9nfqw=="
+      "integrity": "sha512-6knDFNCPJhgbXF10xJWVJb4COe6pvr4pI6wX4B3g9owErZD7oltrqiZS6wtoAH81dZUZFe6ys+kZDpcsH9nfqw==",
+      "optional": true
     },
     "nopt": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cli-progress": "^3.12.0",
     "fs-extra": "^11.1.1",
     "got": "^13.0.0",
-    "node-hide-console-window": "^2.1.1",
     "puppeteer-core": "^20.4.0",
     "sqlite": "^4.2.1",
     "sqlite3": "^5.1.6"
@@ -30,5 +29,8 @@
   "devDependencies": {
     "caxa": "^3.0.1",
     "eslint": "^8.41.0"
+  },
+  "optionalDependencies": {
+    "node-hide-console-window": "^2.1.1"
   }
 }


### PR DESCRIPTION
Heyo, not sure if you're taking pull requests but I added a couple changes so '**node-hide-console-window**' isn't a problem for Linux platforms (probably Mac too) given it's only supported on Windows.

`npm run start` works, however building with caxa doesn't since (I think) the chrome/chromium web browser can't access /tmp directory which by default is where caxa puts its stuff (maybe there's a way to set a local directory?).

Tested on Windows 10 and Ubuntu 22.04 (WSL) by downloading some images from my gallery.